### PR TITLE
add filter options to ConversationFilters.php

### DIFF
--- a/src/Conversations/ConversationFilters.php
+++ b/src/Conversations/ConversationFilters.php
@@ -197,12 +197,14 @@ class ConversationFilters
         Assert::oneOf($sortField, [
             'createdAt',
             'customerEmail',
+            'customerName',
             'mailboxid',
             'modifiedAt',
             'number',
             'score',
             'status',
             'subject',
+            'waitingSince',
         ]);
 
         $filters = clone $this;


### PR DESCRIPTION
Add 2 filter options allowed by HelpScout API which aren't currently in this code. 
https://developer.helpscout.com/mailbox-api/endpoints/conversations/list/#url-parameters

